### PR TITLE
WIDTH instead of 9

### DIFF
--- a/Homeworks/C#1/Primitive-Data-Types-Variables/IsoscelesTriangle/IsoscelesTriangle.cs
+++ b/Homeworks/C#1/Primitive-Data-Types-Variables/IsoscelesTriangle/IsoscelesTriangle.cs
@@ -38,7 +38,7 @@ namespace IsoscelesTriangle
                 Console.WriteLine(outerSpace + copy + innerSpace + copy);
             }
 
-            for (int i = 0; i < 9; i++)
+            for (int i = 0; i < WIDTH; i++)
             {
                 if (i % 2 == 1) Console.Write(' ');
                 else Console.Write(copy);


### PR DESCRIPTION
Hello,

I am a fresh student from the TelerikAcademy and I like how you make your homework. It's quite advanced so it gives me many techniques and hints.
I think it is more correct to use WIDTH in your second for loop in WithLoops() method. This way if you change the size of the triangle, its base will scale accordingly.

Best Regards,
Simeon